### PR TITLE
Get keys both from arrays and objects in GetUnnestedKeys instead of only array

### DIFF
--- a/app/json.go
+++ b/app/json.go
@@ -85,7 +85,7 @@ func GetKeys(jsonData interface{}) ([]string, error) {
 }
 
 func GetUnnestedKeys(jsonData interface{}) ([]string, error) {
-	query, err := gojq.Parse(". | paths(arrays, scalars, booleans)")
+	query, err := gojq.Parse(". | paths")
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse query: %w", err)
 	}

--- a/app/json_test.go
+++ b/app/json_test.go
@@ -63,7 +63,7 @@ func TestGetUnnestedKeys(t *testing.T) {
 		},
 		"status": "active",
 	}
-	want := []string{".status", ".user.age", ".user.name"}
+	want := []string{".status", ".user", ".user.age", ".user.name"}
 
 	got, err := GetUnnestedKeys(input)
 	// Check error cases
@@ -78,7 +78,7 @@ func TestGetUnnestedKeys(t *testing.T) {
 
 	// Use reflect.DeepEqual for comparison
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Got %v, want %v", got, input)
+		t.Errorf("Got %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
Get keys both from arrays and objects in GetUnnestedKeys instead of only array

It shows both `results` and `results[]` but better for me to query

Before
![image](https://github.com/user-attachments/assets/e2cca9fc-aec0-4032-a658-b165f3f110ce)

After
![image](https://github.com/user-attachments/assets/c6a48b04-b0f0-4232-af1c-f4c5b2ac5d26)
