### PR TITLE
Print query history in terminal when you quit UI

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -45,7 +45,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case tea.KeyCtrlS:
 			// Reload based on current query
-			m.queryHist += m.queryEval + "|"
+			if m.queryEval != "." {
+				m.queryHist += m.queryEval + "|"
+			}
 			return m, readOnlyFileExecTeaCmd(m.jsonOutputView.GetJsonData())
 		}
 	case editorFinishedMsg:

--- a/app/main.go
+++ b/app/main.go
@@ -52,8 +52,12 @@ func main() {
 	m.SetJsonData(jsonData)
 
 	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
-	if _, err := p.Run(); err != nil {
+	finalModel, err := p.Run()
+	if err != nil {
 		fmt.Println("Error running program:", err)
 		os.Exit(1)
+	}
+	if finalModel, ok := finalModel.(model); ok {
+		fmt.Printf("jq '%v%v'", finalModel.queryHist, finalModel.queryEval)
 	}
 }


### PR DESCRIPTION
- Run `jqcompletion data/sample.json`
- Query interactively in UI and quit by ctrl+C
- Output the query history in terminal

![image](https://github.com/user-attachments/assets/e7507e59-c447-4ffa-91e6-b4e8d285f16c)
